### PR TITLE
Coffeescript Breakpoints and removal of <button> class

### DIFF
--- a/app/assets/javascripts/initialize.coffee
+++ b/app/assets/javascripts/initialize.coffee
@@ -16,14 +16,14 @@ jQuery(document).on 'turbolinks:load', ->
       }
     },
     {
-      breakpoint: 600,
+      breakpoint: 850,
       settings: {
         slidesToShow: 2,
         slidesToScroll: 2
       }
     },
     {
-      breakpoint: 480,
+      breakpoint: 600,
       settings: {
         slidesToShow: 1,
         slidesToScroll: 1

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -165,12 +165,10 @@
 .card-footer {
     position: absolute;
     bottom: 0;
-    width: 60%;
+    width: 98.5%;
     /* margin-left: -8%; */
     /* margin-right: auto; */
-    font-size: 10px;
     text-align: left;
-    left: 0;
 }
 
 .card-footer-item {

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -46,7 +46,7 @@
             <span class="tag is-success">Trials God</span><br/>
             <span class="tag is-warning"> Top 100 </span>
           </p>
-          
+          <p class="stat-key"></p>
         </div>
       </div>
     </div>
@@ -169,7 +169,7 @@
                 </div>
                 <footer class="card-footer">
                     <a class="card-footer-item">Share Stats</a>
-                    <button class="openmodal myBtn card-footer-item">Post to LFG</button>
+                    <a class="openmodal card-footer-item">Post to LFG</a>
 
                     <!-- The Modal -->
                     <div class="modal myModal">
@@ -218,7 +218,7 @@
                 </div>
                 <footer class="card-footer">
                     <a class="card-footer-item">Share Stats</a>
-                    <button class="openmodal myBtn card-footer-item">Post to LFG</button>
+                    <a class="openmodal card-footer-item">Post to LFG</a>
 
                     <!-- The Modal -->
                     <div class="modal myModal">
@@ -267,7 +267,7 @@
                 </div>
                 <footer class="card-footer">
                     <a class="card-footer-item">Share Stats</a>
-                    <button class="openmodal myBtn card-footer-item">Post to LFG</button>
+                    <a class="openmodal card-footer-item">Post to LFG</a>
 
                     <!-- The Modal -->
                     <div class="modal myModal">
@@ -315,7 +315,7 @@
                 </div>
                 <footer class="card-footer">
                     <a class="card-footer-item">Share Stats</a>
-                    <button class="openmodal myBtn card-footer-item">Post to LFG</button>
+                    <a class="openmodal card-footer-item">Post to LFG</a>
 
                     <!-- The Modal -->
                     <div class="modal myModal">
@@ -364,7 +364,7 @@
                 </div>
                 <footer class="card-footer">
                     <a class="card-footer-item">Share Stats</a>
-                    <button class="openmodal myBtn card-footer-item">Post to LFG</button>
+                    <a class="openmodal card-footer-item">Post to LFG</a>
 
                     <!-- The Modal -->
                     <div class="modal myModal">
@@ -413,7 +413,7 @@
                 </div>
                 <footer class="card-footer">
                     <a class="card-footer-item">Share Stats</a>
-                    <button class="openmodal myBtn card-footer-item">Post to LFG</button>
+                    <a class="openmodal card-footer-item">Post to LFG</a>
 
                     <!-- The Modal -->
                     <div class="modal myModal">
@@ -461,7 +461,7 @@
                 </div>
                 <footer class="card-footer">
                     <a class="card-footer-item">Share Stats</a>
-                    <button class="openmodal myBtn card-footer-item">Post to LFG</button>
+                    <a class="openmodal card-footer-item">Post to LFG</a>
 
                     <!-- The Modal -->
                     <div class="modal myModal">
@@ -509,7 +509,7 @@
                 </div>
                 <footer class="card-footer">
                     <a class="card-footer-item">Share Stats</a>
-                    <button class="openmodal myBtn card-footer-item">Post to LFG</button>
+                    <a class="openmodal card-footer-item">Post to LFG</a>
 
                     <!-- The Modal -->
                     <div class="modal myModal">
@@ -578,7 +578,7 @@
                 </div>
                 <footer class="card-footer">
                     <a class="card-footer-item">Share Stats</a>
-                    <button class="openmodal myBtn card-footer-item">Post to LFG</button>
+                    <a class="openmodal card-footer-item">Post to LFG</a>
 
                     <!-- The Modal -->
                     <div class="modal myModal">
@@ -626,7 +626,7 @@
                 </div>
                 <footer class="card-footer">
                     <a class="card-footer-item">Share Stats</a>
-                    <button class="openmodal myBtn card-footer-item">Post to LFG</button>
+                    <a class="openmodal card-footer-item">Post to LFG</a>
 
                     <!-- The Modal -->
                     <div class="modal myModal">
@@ -678,7 +678,7 @@
 
 
 
-                    <button class="openmodal myBtn card-footer-item">Post to LFG</button>
+                    <a class="openmodal card-footer-item">Post to LFG</a>
 
                     <!-- The Modal -->
                     <div class="modal myModal">
@@ -727,7 +727,7 @@
                 </div>
                 <footer class="card-footer">
                     <a class="card-footer-item">Share Stats</a>
-                    <button class="openmodal myBtn card-footer-item">Post to LFG</button>
+                    <a class="openmodal card-footer-item">Post to LFG</a>
 
                     <!-- The Modal -->
                     <div class="modal myModal">


### PR DESCRIPTION
Updates to Coffeescript Breakpoints  so that text doesn't wrap on the carousel on smaller screens

removal of <button> class on card-footers.  This broke the javascript that we used for the modals, so we will need to find a different way of going about it.